### PR TITLE
chore: CIのワークフローにTestのジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Lint
         run: bun run lint
 
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Test
+        run: bun run test
+
   build:
     runs-on: ubuntu-22.04
     steps:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --ignore-path .gitignore --check . --cache",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
+    "test": "bun test",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
close https://github.com/RICORA/alg-blog/issues/32

## 確認事項

- `bun run test`でテストが実行できる
- mainブランチに向けたPRを立てるとテストが実行される

## 備考

- 今後テストランナーを変更する場合を考慮して、コマンドが変わらないように`bun test`ではなくnpm scriptsを経由して`bun run test`としている