### PR TITLE
docs: 全記事内のSpeaker DeckのURLを修正

### DIFF
--- a/src/content/posts/lt-20220511.mdx
+++ b/src/content/posts/lt-20220511.mdx
@@ -18,8 +18,6 @@ icon: fluent-emoji:pencil
 
 ### C++で意識高い系開発してみた
 
-https://speakerdeck.com/player/ebd082273e474f42bfe0487e5a12b499
-
 C++で物体を検知するコードを開発しました。
 
 ### ベイズ統計モデリングはじめました
@@ -38,13 +36,13 @@ https://docs.google.com/presentation/d/1yCKxpsaNmTpDeXw1a1P04GsgbX417-GAJMhd2Lc7
 
 ### .gitmessageで虚無コミットをやめよう
 
-https://speakerdeck.com/player/c376663f59b94a6cb4c0feba2bceb9e2
+https://speakerdeck.com/phnyo/gitmessagewoshi-tuteding-zhu-nikai-fa-siyou
 
 Gitのコミットメッセージには何を書くべきかの問題を提起しました。
 
 ### Pythonのprint関数にみるポリモーフィズム
 
-https://speakerdeck.com/player/b2428c8b12964e3596ff3776d5d5c1d1
+https://speakerdeck.com/shinonome517/slide-for-lt-20220511
 
 Pythonのprint関数の実装を考察し、自作のデータ構造も引数にとれることを確認しました。
 

--- a/src/content/posts/lt-20220622.mdx
+++ b/src/content/posts/lt-20220622.mdx
@@ -20,7 +20,7 @@ icon: fluent-emoji:pencil
 
 NNの基礎からVision Transformerまで説明をしました。
 
-https://speakerdeck.com/player/6e377f6246ff405db4766aec03a8f5e8
+https://speakerdeck.com/shun74/plz-understand-vit
 
 ### 正規表現→NFA→DFA
 

--- a/src/content/posts/lt-20220713.mdx
+++ b/src/content/posts/lt-20220713.mdx
@@ -18,11 +18,11 @@ icon: fluent-emoji:pencil
 
 ### C++で書いた末尾再帰を最適化したい
 
-https://speakerdeck.com/player/7b9e32eb1ba34fa6bc7ba64b192cdef2
+https://speakerdeck.com/shinonome517/cpp-tail-recursion-elimination
 
 ### ニューラルネットの1bit化
 
-https://speakerdeck.com/player/25e82ada9e574db7b03768f629b35185
+https://speakerdeck.com/shun74/1bit-neural-network
 
 ### これが本物のコピペプログラム
 
@@ -30,6 +30,6 @@ https://speakerdeck.com/player/25e82ada9e574db7b03768f629b35185
 
 ### 少し幸せになれるスマートリモコンを作る
 
-https://speakerdeck.com/player/91a020b63858445ea467a13d94c2968e
+https://speakerdeck.com/sou1118/making-a-smart-remote-controller
 
 ### Djangoでweb開発

--- a/src/content/posts/lt-20220914.mdx
+++ b/src/content/posts/lt-20220914.mdx
@@ -28,7 +28,7 @@ https://docs.google.com/presentation/d/1H7ojkuO4AEZg-aHOJAjRnMQVVFRojYxcD3f51jRp
 
 ### Google ColaboratoryでStable Diffusionの実装
 
-https://speakerdeck.com/player/7002459ea9944f97b0f926f2edbcf20a
+https://speakerdeck.com/tasotaku/implementation-of-stable-diffusion-at-google-colaboratory
 
 ### 製作中の音ゲーの実装について
 

--- a/src/content/posts/lt-20221109.mdx
+++ b/src/content/posts/lt-20221109.mdx
@@ -18,7 +18,7 @@ icon: fluent-emoji:pencil
 
 ### Vision Transformer講座
 
-https://speakerdeck.com/player/e584fcf8fb744159846ef440b0847a20
+https://speakerdeck.com/shun74/vision-transformer-presentation
 
 ### スクラップ型技術記事のススメ
 
@@ -26,15 +26,15 @@ https://alg-slides.tus-ricora.com/scrap.html
 
 ### マイナンバーカード の有効利用法を探る
 
-https://speakerdeck.com/player/8dbb6209e0f44a0a845f0363758bafe5
+https://speakerdeck.com/sou1118/finding-ways-to-use-my-number-card
 
 ### ベイズで単回帰モデルを考える
 
-https://speakerdeck.com/player/8295d658c7104076974bf57f3c3fbb8a
+https://speakerdeck.com/thimblee/bayes-simple-linear-regression
 
 ### Streamlitで簡単なアプリを作ってみた
 
-https://speakerdeck.com/player/9d9013cb1cad423d9fa10809132779ea
+https://speakerdeck.com/push1223/streamlit-app
 
 ### Terminal User Interfaceの話
 

--- a/src/content/posts/lt-20221116.mdx
+++ b/src/content/posts/lt-20221116.mdx
@@ -18,14 +18,14 @@ icon: fluent-emoji:pencil
 
 ### &lt;計算可能&rt;を素朴に考える
 
-https://speakerdeck.com/player/1bf7fc1f0bd14624a94013534e2e0aa6
+https://speakerdeck.com/000meta/an-introduction-to-computability
 
 ### DPを使ったナップザック問題の解き方
 
-https://speakerdeck.com/player/44b4f85ed2334129ba743d0972ab1dfb
+https://speakerdeck.com/d_kura/solve-knapsack-problem-with-dp
 
 ### 統計学を学びたい
 
 ### tauriでspotlight的なアプリを作ってる話
 
-https://speakerdeck.com/player/020fb06892884957b00e8886ead5de5c
+https://speakerdeck.com/e9716/talk-about-developing-a-spotlight-like-application-in-tauri

--- a/src/content/posts/lt-20221221.mdx
+++ b/src/content/posts/lt-20221221.mdx
@@ -18,16 +18,16 @@ icon: fluent-emoji:pencil
 
 ### AIが作る予想外な画像を考える
 
-https://speakerdeck.com/player/67dfca8cb48a4817ae84580f6653ac1d
+https://speakerdeck.com/tasotaku/consider-the-unexpected-images-that-ai-creates
 
 ### 卒業研究の進め方
 
-https://speakerdeck.com/player/af9e3ae4cea542f8a4c7239c93308c77
+https://speakerdeck.com/shun74/how-to-preceed-with-the-research
 
 ### 巡回セールスマン問題での貪欲法の精度
 
-https://speakerdeck.com/player/92c3763f5e2b46caa96902dae28cbf7f
+https://speakerdeck.com/thimblee/accuracy-of-greedy-method-in-tsp
 
 ### スライド操作用リモコンを作った話
 
-https://speakerdeck.com/player/3543e5835f4e45a485b7d4cc9c2da9a2
+https://speakerdeck.com/sou1118/making-a-remote-control-for-slide-operation

--- a/src/content/posts/lt-20230602.mdx
+++ b/src/content/posts/lt-20230602.mdx
@@ -18,7 +18,7 @@ icon: fluent-emoji:pencil
 
 ### QPACKって何？
 
-https://speakerdeck.com/player/6ae22359ef00428796d4f2b7c2ab9ab7
+https://speakerdeck.com/sou1118/what-is-qpack
 
 ### Windowsはクソ
 
@@ -26,4 +26,4 @@ https://speakerdeck.com/player/6ae22359ef00428796d4f2b7c2ab9ab7
 
 ### 私、ChatGPTがChatGPTを解説するよ！
 
-https://speakerdeck.com/player/abb856822d0a4f848fbc78f3796002af
+https://speakerdeck.com/tasotaku/chatgpt-explains-chatgpt

--- a/src/content/posts/machine-learning-lecture-2023.mdx
+++ b/src/content/posts/machine-learning-lecture-2023.mdx
@@ -16,6 +16,6 @@ icon: fluent-emoji:robot
 
 使用したスライド資料およびリポジトリは以下の通りです。
 
-https://speakerdeck.com/player/97a870869d094cd0b5009b75f0f4284d
+https://speakerdeck.com/tasotaku/ml-lec
 
 https://github.com/tasotaku/machine-learning-lec

--- a/src/content/posts/ridaisai-2022.mdx
+++ b/src/content/posts/ridaisai-2022.mdx
@@ -69,7 +69,7 @@ Raspberry Piを用いてバーコードを認識するデバイスです。
 
 ![Raspberry Piを用いたバーコード認識の展示の様子](https://user-images.githubusercontent.com/52315048/236246557-d49e2282-8276-4f02-b2a1-ffaf2516e86b.jpg)
 
-https://speakerdeck.com/player/268658bded8f4cca9bb018f6a4ce01fa
+https://speakerdeck.com/shun74/pharmacode-decoder
 
 https://github.com/shun74/Barcode-Recognition
 
@@ -89,7 +89,7 @@ https://github.com/shun74/Barcode-Recognition
 
 時系列データの解析では、通常のデータと比べてさまざまなことに気を配る必要があります。そこで、時系列解析をスムーズに進めるためのフレームワークの理論と実装について紹介します。
 
-https://speakerdeck.com/player/e60494607fe0496cbdde1ef48a1e0983
+https://speakerdeck.com/saburoku/theory-and-implementation-of-classical-time-series-analysis-frameworks
 
 #### 数値解析の誤差とその対策法
 
@@ -101,4 +101,4 @@ https://drive.google.com/drive/folders/1OFi31Xr09r26u49lcKx7eR7aIGHorV1E
 
 マイナンバーカード内の証明書は個人でも利用できることはご存知ですか？この証明書を用いて公開鍵認証をする方法について考察します。
 
-https://speakerdeck.com/player/10b80f0eab9c4b96bc701b4c60fc1bd5
+https://speakerdeck.com/sou1118/authentication-using-the-my-number-card

--- a/src/content/posts/vulkan-lecture-2023.mdx
+++ b/src/content/posts/vulkan-lecture-2023.mdx
@@ -16,6 +16,6 @@ icon: fluent-emoji:volcano
 
 使用したスライド資料およびリポジトリは以下の通りです。
 
-https://speakerdeck.com/player/31fcdaf948dd42d88e20c87de3b3eefd
+https://speakerdeck.com/tengu712/simplest-vulkan-tutorial-in-japanese
 
 https://github.com/Tengu712/Vulkan-Tutorial


### PR DESCRIPTION
close https://github.com/ricora/alg-blog/issues/55

## 確認事項

- URLが全て置換されている
  - `https://speakerdeck.com/player/`から始まるURLが存在しない
- URLが正しく置換されている

## 備考

- 現在既に削除されて存在しないスライドは本文からも削除している
