### PR TITLE
fix: remarkEmbedでGoogle Slidesの埋め込みテストが確率的に失敗するバグを修正

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
       [
         remarkEmbed,
         {
-          transformers: [oEmbedTransformer, googleSlidesTransformer],
+          transformers: [googleSlidesTransformer, oEmbedTransformer],
         } satisfies RemarkEmbedOptions,
       ],
       remarkLinkCard,

--- a/src/lib/remark-plugins/remarkEmbed.test.ts
+++ b/src/lib/remark-plugins/remarkEmbed.test.ts
@@ -17,7 +17,7 @@ const process = async (md: string) => {
     await unified()
       .use(remarkParse)
       .use(remarkEmbed, {
-        transformers: [oEmbedTransformer, googleSlidesTransformer],
+        transformers: [googleSlidesTransformer, oEmbedTransformer],
       })
       .use(() => (tree: mdast.Root) => {
         mdast = tree


### PR DESCRIPTION
## 原因

oEmbedTransformerでURLのメタ情報を取得する際にエラーとなり、googleSlidesTransformerまで処理が回らず埋め込みに失敗する。

```typescript
// src/lib/remark-plugins/remarkEmbed.ts (20-32行目)
export const oEmbedTransformer: Readonly<Transformer> = {
  hName: "oembed",
  hProperties: async (url) => {
    const metadata = await unfurl(url.href)  // ここでfetchエラーが出る

    if (metadata.oEmbed != null) return { oEmbed: JSON.stringify(metadata.oEmbed) }
    return {} as HProperties
  },
  match: async (url) => {
    const metadata = await unfurl(url.href)
    return metadata.oEmbed != null
  },
}
``` 

エラーの例：

```json
{
    "code": "Malformed_HTTP_Response",
    "path": "https://docs.google.com/presentation/d/1t-XdfXzd3l8CdfriQWOljuOleKHIdnomCHcIffSEZA4/",
    "errno": 0
}
```

エラーとなっているGitHub Actionsの例：https://github.com/ricora/alg-blog/actions/runs/7765970616

## 変更点

応急処置として、oEmbedTransformerの前にgoogleSlidesTransformerを優先して実行するように変更した。これにより、oEmbedTransformerでfetchに失敗する前にgoogleSlidesとして埋め込まれるため、エラーとならずに済む。