### PR TITLE
feat: YouTubeの埋め込みを実装

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -16,6 +16,7 @@ import {
   googleSlidesTransformer,
   oEmbedTransformer,
   remarkEmbed,
+  youTubeTransformer,
   type RemarkEmbedOptions,
 } from "./src/lib/remark-plugins/remarkEmbed"
 import remarkMath from "remark-math"
@@ -38,7 +39,7 @@ export default defineConfig({
       [
         remarkEmbed,
         {
-          transformers: [googleSlidesTransformer, oEmbedTransformer],
+          transformers: [youTubeTransformer, googleSlidesTransformer, oEmbedTransformer],
         } satisfies RemarkEmbedOptions,
       ],
       remarkLinkCard,

--- a/src/content/posts/hello-world-v2/index.mdx
+++ b/src/content/posts/hello-world-v2/index.mdx
@@ -156,6 +156,8 @@ https://github.com/RICORA/alg-blog
 
 https://www.youtube.com/watch?v=Gy5vAs_jQSo
 
+https://www.youtube.com/embed/Gy5vAs_jQSo
+
 https://www.slideshare.net/RuiWatanabe3/marp-tutorial
 
 https://speakerdeck.com/morganepeng/design-and-strategy-how-to-deal-with-people-who-dont-get-design

--- a/src/lib/remark-plugins/remarkEmbed.ts
+++ b/src/lib/remark-plugins/remarkEmbed.ts
@@ -33,6 +33,31 @@ export const oEmbedTransformer: Readonly<Transformer> = {
   },
 }
 
+export const youTubeTransformer: Readonly<Transformer> = {
+  hName: "iframe",
+  hProperties: async (url): Promise<HProperties> => {
+    const convertToEmbedUrl = (url: string): string => {
+      const regExp = /^.*(watch\?v=|embed\/)([^#&?]*).*/
+      const match = url.match(regExp)
+
+      if (match && match[2]) {
+        return "https://www.youtube.com/embed/" + match[2]
+      } else {
+        throw new Error("Invalid YouTube URL")
+      }
+    }
+
+    return {
+      src: convertToEmbedUrl(url.href),
+      width: "100%",
+      height: "360",
+    }
+  },
+  match: async (url) => {
+    return url.hostname === "www.youtube.com"
+  },
+}
+
 export const googleSlidesTransformer: Readonly<Transformer> = {
   hName: "iframe",
   hProperties: async (url): Promise<HProperties> => {


### PR DESCRIPTION
close https://github.com/ricora/alg-blog/issues/23

## 確認事項

- 以下の形式のYouTubeの動画のURLが埋め込みになる
  - `https://www.youtube.com/watch?v=`から始まるURL
  - `https://www.youtube.com/embed/`から始まるURL

## 備考

YouTubeの動画のURLの形式は以下のように色々あるが、上記の形式のサポートのみで十分であると判断して敢えて実装していない。

https://gist.github.com/rodrigoborgesdeoliveira/987683cfbfcc8d800192da1e73adc486