### PR TITLE
feat: カテゴリとタグの絞り込み表示を実装

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -29,7 +29,6 @@ export default defineConfig({
   site: "https://alg.tus-ricora.com/",
   redirects: {
     "/p/[...slug]": "/posts/[...slug]",
-    "/[...slug]": "/categories/[...slug]",
   },
   integrations: [tailwind(), solidJs(), mdx(), sitemap(), pagefind()],
   markdown: {

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   site: "https://alg.tus-ricora.com/",
   redirects: {
     "/p/[...slug]": "/posts/[...slug]",
+    "/[...slug]": "/categories/[...slug]",
   },
   integrations: [tailwind(), solidJs(), mdx(), sitemap(), pagefind()],
   markdown: {

--- a/src/components/SideBar/NavBar/Links.astro
+++ b/src/components/SideBar/NavBar/Links.astro
@@ -15,17 +15,17 @@ const links: Link[] = [
   {
     title: "お知らせ",
     icon: "tabler:news",
-    href: "/news",
+    href: "/categories/news",
   },
   {
     title: "活動記録",
     icon: "tabler:activity",
-    href: "/activities",
+    href: "/categories/activities",
   },
   {
     title: "作品紹介",
     icon: "tabler:star",
-    href: "/works",
+    href: "/categories/works",
   },
   {
     title: "タグ",

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,6 +1,11 @@
+import { getCollection } from "astro:content"
+import { isDev } from "./runtime"
+
 /**
  * 与えられたMarkdownの文字列から、読了時間を計算する
  * @argument content Markdownの文字列
  * @returns 読了時間（分）
  */
 export const calculateReadingTime = (content: string) => Math.max(1, Math.round(content.length / 600))
+
+export const getPosts = () => getCollection("posts", ({ data }) => (isDev ? true : !data.draft))

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,32 @@
+import { getCollection } from "astro:content"
+import { getPosts } from "./posts"
+
+export type Tag = {
+  id: string
+  title: string
+}
+
+export const getTags = async (): Promise<Tag[]> => {
+  const posts = await getPosts()
+  const tagCollection = await getCollection("tags")
+
+  const tagIdToTitle = tagCollection.reduce<{ [key: string]: string }>((acc, { id, data }) => {
+    acc[id] = data.title
+    return acc
+  }, {})
+  const tagIdList = posts.reduce<string[]>((acc, { data }) => {
+    if (data.tags) {
+      data.tags.forEach((tag) => {
+        if (!acc.includes(tag)) {
+          acc.push(tag)
+        }
+      })
+    }
+    return acc
+  }, [])
+
+  return tagIdList.map((tagId) => ({
+    id: tagId,
+    title: tagId in tagIdToTitle ? tagIdToTitle[tagId] : tagId,
+  }))
+}

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -3,12 +3,11 @@ import { Icon, type IconName } from "@/components/Elements/Icon"
 import { Tabs, type TabsProps } from "@/components/Elements/Tabs"
 import { BaseLayout } from "@/layouts/BaseLayout"
 import { formatDate } from "@/lib/date"
-import { calculateReadingTime } from "@/lib/posts"
-import { isDev } from "@/lib/runtime"
+import { calculateReadingTime, getPosts } from "@/lib/posts"
 import { getCollection } from "astro:content"
 import { twMerge } from "tailwind-merge"
 
-const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
+const posts = await getPosts()
 posts.sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
 
 const categories = await getCollection("categories")

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -88,7 +88,7 @@ const tabProps: TabsProps = {
                                 const category = categories.find((category) => category.id === id)!
                                 return (
                                   <a
-                                    href={`/${id}`}
+                                    href={`/categories/${id}`}
                                     class={twMerge(
                                       "flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
                                       category.data.twClassName,

--- a/src/pages/categories/[...slug]/index.astro
+++ b/src/pages/categories/[...slug]/index.astro
@@ -59,7 +59,7 @@ const postsByCategory = posts
                     const category = categories.find((category) => category.id === id)!
                     return (
                       <a
-                        href={`/${id}`}
+                        href={`/categories/${id}`}
                         class={twMerge(
                           "flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
                           category.data.twClassName,

--- a/src/pages/categories/[...slug]/index.astro
+++ b/src/pages/categories/[...slug]/index.astro
@@ -1,0 +1,100 @@
+---
+import { Icon, type IconName } from "@/components/Elements/Icon"
+import { BaseLayout } from "@/layouts/BaseLayout"
+import { formatDate } from "@/lib/date"
+import { calculateReadingTime, getPosts } from "@/lib/posts"
+import { getCollection } from "astro:content"
+import * as path from "node:path"
+import { twMerge } from "tailwind-merge"
+
+export const getStaticPaths = async () => {
+  const tags = await getCollection("categories")
+  return tags.map((category) => ({
+    params: {
+      slug: category.id,
+    },
+    props: {
+      category,
+    },
+  }))
+}
+
+const { category } = Astro.props
+
+const posts = await getPosts()
+const categories = await getCollection("categories")
+
+const postsByCategory = posts
+  .filter((post) => post.data.categories.some((postCategory) => postCategory.id === category.id))
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+---
+
+<BaseLayout title={category.data.title} og={{ url: new URL(path.join("tags", category.id), Astro.site) }}>
+  <main class="flex flex-1 flex-col gap-8 py-12">
+    <header class="flex flex-col gap-6">
+      <h1 class="flex flex-row items-center gap-2 text-3xl font-bold sm:text-4xl md:gap-3 md:text-5xl">
+        <Icon name={category.data.icon as IconName} class="h-10 w-10 sm:h-12 sm:w-12 md:h-16 md:w-16" />
+        {category.data.title}
+      </h1>
+      <p class="text-muted-foreground sm:text-lg">
+        "{category.data.title}"に関連する{postsByCategory.length}件の記事を表示しています。
+      </p>
+    </header>
+    <div class="flex flex-col gap-6">
+      <!-- 仮のモックアップ -->
+      {
+        postsByCategory.map((post, i) => (
+          <div
+            class="flex flex-row items-center gap-2 rounded-xl bg-card/50 p-4 shadow-md backdrop-blur-lg duration-1000 ease-out animate-in fade-in-0 slide-in-from-bottom-6 hover:bg-muted/60"
+            style={{
+              "animation-delay": `${i * 160}ms`,
+              "animation-fill-mode": "backwards",
+            }}
+          >
+            <Icon name={post.data.icon as IconName} class="w-20 flex-none rounded-2xl p-4 sm:w-28 sm:p-6" />
+            <div class="my-2 flex flex-col gap-2.5 sm:gap-4">
+              <header>
+                <div class="flex flex-row flex-wrap gap-2">
+                  {post.data.categories.map(({ id }) => {
+                    const category = categories.find((category) => category.id === id)!
+                    return (
+                      <a
+                        href={`/${id}`}
+                        class={twMerge(
+                          "flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
+                          category.data.twClassName,
+                        )}
+                      >
+                        <Icon name={category.data.icon as IconName} class="h-5 w-5" />
+                        <div>{category.data.title}</div>
+                      </a>
+                    )
+                  })}
+                </div>
+              </header>
+              <a href={`/posts/${post.slug}`}>
+                <h2 class="text-lg font-black sm:text-xl md:text-2xl">{post.data.title}</h2>
+              </a>
+              <footer class="flex flex-row flex-wrap gap-2 text-xs font-semibold text-gray-500 sm:gap-4 sm:text-sm">
+                <div class="flex flex-row items-center gap-2">
+                  <Icon name="tabler:calendar-time" class="h-4 w-4 sm:h-5 sm:w-5" />
+                  <span>投稿: {formatDate(post.data.date)}</span>
+                </div>
+                {post.data.lastmod && (
+                  <div class="flex flex-row items-center gap-2">
+                    <Icon name="tabler:refresh" class="h-5 w-5" />
+                    <span>最終更新: {formatDate(post.data.lastmod)}</span>
+                  </div>
+                )}
+                <div class="flex flex-row items-center gap-2">
+                  <Icon name="tabler:clock" class="h-5 w-5" />
+                  <span>読了時間: 約{calculateReadingTime(post.body)}分</span>
+                </div>
+              </footer>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,7 @@ const categories = await getCollection("categories")
                     const category = categories.find((category) => category.id === id)!
                     return (
                       <a
-                        href={`/${id}`}
+                        href={`/categories/${id}`}
                         class={twMerge(
                           "flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
                           category.data.twClassName,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,12 @@
 ---
 import { Icon, type IconName } from "@/components/Elements/Icon"
 import { BaseLayout } from "@/layouts/BaseLayout"
-import { isDev } from "@/lib/runtime"
 import { getCollection } from "astro:content"
 import { formatDate } from "@/lib/date"
-import { calculateReadingTime } from "@/lib/posts"
+import { calculateReadingTime, getPosts } from "@/lib/posts"
 import { twMerge } from "tailwind-merge"
 
-const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
+const posts = await getPosts()
 const categories = await getCollection("categories")
 ---
 

--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -1,12 +1,11 @@
 ---
 import "katex/dist/katex.min.css"
-import { isDev } from "@/lib/runtime"
-import { getCollection } from "astro:content"
 import type { CollectionEntry } from "astro:content"
 import { PostLayout } from "@/layouts/PostLayout"
+import { getPosts } from "@/lib/posts"
 
 export const getStaticPaths = async () => {
-  const postEntries = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
+  const postEntries = await getPosts()
   return postEntries.map((post) => ({
     params: {
       slug: post.slug,

--- a/src/pages/tags/[...slug]/index.astro
+++ b/src/pages/tags/[...slug]/index.astro
@@ -7,41 +7,9 @@ import { isDev } from "@/lib/runtime"
 import { getCollection } from "astro:content"
 import * as path from "node:path"
 import { twMerge } from "tailwind-merge"
-
-type Tag = {
-  id: string
-  title: string
-}
+import { getTags } from "@/lib/tags"
 
 export const getStaticPaths = async () => {
-  const getTags = async (): Promise<Tag[]> => {
-    const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
-    const tagCollection = await getCollection("tags")
-
-    const tagIdToTitle = tagCollection.reduce(
-      (acc, { id, data }) => {
-        acc[id] = data.title
-        return acc
-      },
-      {} as { [key: string]: string },
-    )
-    const tagIdList = posts.reduce((acc, { data }) => {
-      if (data.tags) {
-        data.tags.forEach((tag) => {
-          if (!acc.includes(tag)) {
-            acc.push(tag)
-          }
-        })
-      }
-      return acc
-    }, [] as string[])
-
-    return tagIdList.map((tagId) => ({
-      id: tagId,
-      title: tagId in tagIdToTitle ? tagIdToTitle[tagId] : tagId,
-    }))
-  }
-
   const tags = await getTags()
   return tags.map((tag) => ({
     params: {

--- a/src/pages/tags/[...slug]/index.astro
+++ b/src/pages/tags/[...slug]/index.astro
@@ -6,42 +6,41 @@ import { calculateReadingTime, getPosts } from "@/lib/posts"
 import { getCollection } from "astro:content"
 import * as path from "node:path"
 import { twMerge } from "tailwind-merge"
-import { getTags } from "@/lib/tags"
 
 export const getStaticPaths = async () => {
-  const tags = await getTags()
-  return tags.map((tag) => ({
+  const tags = await getCollection("categories")
+  return tags.map((category) => ({
     params: {
-      slug: tag.id,
+      slug: category.id,
     },
     props: {
-      tag,
+      category,
     },
   }))
 }
 
-const { tag } = Astro.props
+const { category } = Astro.props
 
 const posts = await getPosts()
 const categories = await getCollection("categories")
 
-const postsByTag = posts
-  .filter((post) => post.data.tags?.includes(tag.id))
+const postsByCategory = posts
+  .filter((post) => post.data.categories.some((category) => category.id === category.id))
   .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
 ---
 
-<BaseLayout title={tag.title} og={{ url: new URL(path.join("tags", tag.id), Astro.site) }}>
+<BaseLayout title={category.data.title} og={{ url: new URL(path.join("tags", category.id), Astro.site) }}>
   <main class="flex flex-1 flex-col gap-8 py-12">
     <header class="flex flex-col gap-6">
-      <h1 class="text-3xl font-bold sm:text-4xl md:text-5xl">{tag.title}</h1>
+      <h1 class="text-3xl font-bold sm:text-4xl md:text-5xl">{category.data.title}</h1>
       <p class="text-muted-foreground sm:text-lg">
-        "{tag.title}"に関連する{postsByTag.length}件の記事を表示しています。
+        "{category.data.title}"に関連する{postsByCategory.length}件の記事を表示しています。
       </p>
     </header>
     <div class="flex flex-col gap-6">
       <!-- 仮のモックアップ -->
       {
-        postsByTag.map((post, i) => (
+        postsByCategory.map((post, i) => (
           <div
             class="flex flex-row items-center gap-2 rounded-xl bg-card/50 p-4 shadow-md backdrop-blur-lg duration-1000 ease-out animate-in fade-in-0 slide-in-from-bottom-6 hover:bg-muted/60"
             style={{
@@ -57,7 +56,7 @@ const postsByTag = posts
                     const category = categories.find((category) => category.id === id)!
                     return (
                       <a
-                        href={`/${id}`}
+                        href={`/categories/${id}`}
                         class={twMerge(
                           "flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
                           category.data.twClassName,

--- a/src/pages/tags/[...slug]/index.astro
+++ b/src/pages/tags/[...slug]/index.astro
@@ -2,8 +2,7 @@
 import { Icon, type IconName } from "@/components/Elements/Icon"
 import { BaseLayout } from "@/layouts/BaseLayout"
 import { formatDate } from "@/lib/date"
-import { calculateReadingTime } from "@/lib/posts"
-import { isDev } from "@/lib/runtime"
+import { calculateReadingTime, getPosts } from "@/lib/posts"
 import { getCollection } from "astro:content"
 import * as path from "node:path"
 import { twMerge } from "tailwind-merge"
@@ -23,7 +22,7 @@ export const getStaticPaths = async () => {
 
 const { tag } = Astro.props
 
-const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
+const posts = await getPosts()
 const categories = await getCollection("categories")
 
 const postsByTag = posts

--- a/src/pages/tags/[...slug]/index.astro
+++ b/src/pages/tags/[...slug]/index.astro
@@ -1,0 +1,131 @@
+---
+import { Icon, type IconName } from "@/components/Elements/Icon"
+import { BaseLayout } from "@/layouts/BaseLayout"
+import { formatDate } from "@/lib/date"
+import { calculateReadingTime } from "@/lib/posts"
+import { isDev } from "@/lib/runtime"
+import { getCollection } from "astro:content"
+import * as path from "node:path"
+import { twMerge } from "tailwind-merge"
+
+type Tag = {
+  id: string
+  title: string
+}
+
+export const getStaticPaths = async () => {
+  const getTags = async (): Promise<Tag[]> => {
+    const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
+    const tagCollection = await getCollection("tags")
+
+    const tagIdToTitle = tagCollection.reduce(
+      (acc, { id, data }) => {
+        acc[id] = data.title
+        return acc
+      },
+      {} as { [key: string]: string },
+    )
+    const tagIdList = posts.reduce((acc, { data }) => {
+      if (data.tags) {
+        data.tags.forEach((tag) => {
+          if (!acc.includes(tag)) {
+            acc.push(tag)
+          }
+        })
+      }
+      return acc
+    }, [] as string[])
+
+    return tagIdList.map((tagId) => ({
+      id: tagId,
+      title: tagId in tagIdToTitle ? tagIdToTitle[tagId] : tagId,
+    }))
+  }
+
+  const tags = await getTags()
+  return tags.map((tag) => ({
+    params: {
+      slug: tag.id,
+    },
+    props: {
+      tag,
+    },
+  }))
+}
+
+const { tag } = Astro.props
+
+const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
+const categories = await getCollection("categories")
+
+const postsByTag = posts
+  .filter((post) => post.data.tags?.includes(tag.id))
+  .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+---
+
+<BaseLayout title={tag.title} og={{ url: new URL(path.join("tags", tag.id), Astro.site) }}>
+  <main class="flex flex-1 flex-col gap-8 py-12">
+    <header class="flex flex-col gap-6">
+      <h1 class="text-3xl font-bold sm:text-4xl md:text-5xl">{tag.title}</h1>
+      <p class="text-muted-foreground sm:text-lg">
+        "{tag.title}"に関連する{postsByTag.length}件の記事を表示しています。
+      </p>
+    </header>
+    <div class="flex flex-col gap-6">
+      <!-- 仮のモックアップ -->
+      {
+        postsByTag.map((post, i) => (
+          <div
+            class="flex flex-row items-center gap-2 rounded-xl bg-card/50 p-4 shadow-md backdrop-blur-lg duration-1000 ease-out animate-in fade-in-0 slide-in-from-bottom-6 hover:bg-muted/60"
+            style={{
+              "animation-delay": `${i * 160}ms`,
+              "animation-fill-mode": "backwards",
+            }}
+          >
+            <Icon name={post.data.icon as IconName} class="w-20 flex-none rounded-2xl p-4 sm:w-28 sm:p-6" />
+            <div class="my-2 flex flex-col gap-2.5 sm:gap-4">
+              <header>
+                <div class="flex flex-row flex-wrap gap-2">
+                  {post.data.categories.map(({ id }) => {
+                    const category = categories.find((category) => category.id === id)!
+                    return (
+                      <a
+                        href={`/${id}`}
+                        class={twMerge(
+                          "flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
+                          category.data.twClassName,
+                        )}
+                      >
+                        <Icon name={category.data.icon as IconName} class="h-5 w-5" />
+                        <div>{category.data.title}</div>
+                      </a>
+                    )
+                  })}
+                </div>
+              </header>
+              <a href={`/posts/${post.slug}`}>
+                <h2 class="text-lg font-black sm:text-xl md:text-2xl">{post.data.title}</h2>
+              </a>
+              <footer class="flex flex-row flex-wrap gap-2 text-xs font-semibold text-gray-500 sm:gap-4 sm:text-sm">
+                <div class="flex flex-row items-center gap-2">
+                  <Icon name="tabler:calendar-time" class="h-4 w-4 sm:h-5 sm:w-5" />
+                  <span>投稿: {formatDate(post.data.date)}</span>
+                </div>
+                {post.data.lastmod && (
+                  <div class="flex flex-row items-center gap-2">
+                    <Icon name="tabler:refresh" class="h-5 w-5" />
+                    <span>最終更新: {formatDate(post.data.lastmod)}</span>
+                  </div>
+                )}
+                <div class="flex flex-row items-center gap-2">
+                  <Icon name="tabler:clock" class="h-5 w-5" />
+                  <span>読了時間: 約{calculateReadingTime(post.body)}分</span>
+                </div>
+              </footer>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/tags/[...slug]/index.astro
+++ b/src/pages/tags/[...slug]/index.astro
@@ -6,41 +6,42 @@ import { calculateReadingTime, getPosts } from "@/lib/posts"
 import { getCollection } from "astro:content"
 import * as path from "node:path"
 import { twMerge } from "tailwind-merge"
+import { getTags } from "@/lib/tags"
 
 export const getStaticPaths = async () => {
-  const tags = await getCollection("categories")
-  return tags.map((category) => ({
+  const tags = await getTags()
+  return tags.map((tag) => ({
     params: {
-      slug: category.id,
+      slug: tag.id,
     },
     props: {
-      category,
+      tag,
     },
   }))
 }
 
-const { category } = Astro.props
+const { tag } = Astro.props
 
 const posts = await getPosts()
 const categories = await getCollection("categories")
 
-const postsByCategory = posts
-  .filter((post) => post.data.categories.some((category) => category.id === category.id))
+const postsByTag = posts
+  .filter((post) => post.data.tags?.includes(tag.id))
   .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
 ---
 
-<BaseLayout title={category.data.title} og={{ url: new URL(path.join("tags", category.id), Astro.site) }}>
+<BaseLayout title={tag.title} og={{ url: new URL(path.join("tags", tag.id), Astro.site) }}>
   <main class="flex flex-1 flex-col gap-8 py-12">
     <header class="flex flex-col gap-6">
-      <h1 class="text-3xl font-bold sm:text-4xl md:text-5xl">{category.data.title}</h1>
+      <h1 class="text-3xl font-bold sm:text-4xl md:text-5xl">{tag.title}</h1>
       <p class="text-muted-foreground sm:text-lg">
-        "{category.data.title}"に関連する{postsByCategory.length}件の記事を表示しています。
+        "{tag.title}"に関連する{postsByTag.length}件の記事を表示しています。
       </p>
     </header>
     <div class="flex flex-col gap-6">
       <!-- 仮のモックアップ -->
       {
-        postsByCategory.map((post, i) => (
+        postsByTag.map((post, i) => (
           <div
             class="flex flex-row items-center gap-2 rounded-xl bg-card/50 p-4 shadow-md backdrop-blur-lg duration-1000 ease-out animate-in fade-in-0 slide-in-from-bottom-6 hover:bg-muted/60"
             style={{

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,29 +1,9 @@
 ---
 import { Tabs, type TabsProps } from "@/components/Elements/Tabs"
 import { BaseLayout } from "@/layouts/BaseLayout"
-import { isDev } from "@/lib/runtime"
-import { getCollection } from "astro:content"
+import { getTags } from "@/lib/tags"
 
-const posts = await getCollection("posts", ({ data }) => (isDev ? true : !data.draft))
-
-const tagCollection = await getCollection("tags")
-
-const tagIdToTitle: { [key: string]: string } = {}
-
-for (const tag of tagCollection) {
-  tagIdToTitle[tag.id] = tag.data.title
-}
-
-const tagSlugs: string[] = []
-for (const post of posts) {
-  if (post.data && post.data.tags) {
-    for (const tag of post.data.tags) {
-      if (!tagSlugs.includes(tag)) {
-        tagSlugs.push(tag)
-      }
-    }
-  }
-}
+const tags = await getTags()
 
 const tabProps: TabsProps = {
   tabs: [
@@ -61,14 +41,14 @@ const tabProps: TabsProps = {
 
     <div class="flex flex-wrap">
       {
-        tagSlugs.map((tag) => (
+        tags.map((tag) => (
           <a
-            href={`/tags/${tag}`}
+            href={`/tags/${tag.id}`}
             class="m-1 rounded-lg border border-gray-300 bg-gray-50 px-4 py-2 text-sm transition hover:brightness-90 dark:border-gray-700 dark:bg-gray-950"
           >
             <>
               <span class="pr-1 text-xs text-muted-foreground">#</span>
-              <span>{Object.prototype.hasOwnProperty.call(tagIdToTitle, tag) ? tagIdToTitle[tag] : tag}</span>
+              <span>{tag.title}</span>
             </>
           </a>
         ))


### PR DESCRIPTION
close #84 

## 変更点

- `/tags/${tag}`で`tag`をもつ記事の一覧を表示
- `/categories/${category}`で`category`をもつ記事の一覧を表示
- その他リファクタリング：
  - tagの取得に関するコードを共通化
  - 記事を取得するコードを共通化

## 確認事項

- `/tags/${tag}`で`tag`をもつ記事の一覧が閲覧できること
- `/categories/${category}`で`category`をもつ記事の一覧が閲覧できること