### PR TITLE
feat: カテゴリ一覧ページのベースを実装

### DIFF
--- a/src/components/Elements/PostCard/CategoryCard.tsx
+++ b/src/components/Elements/PostCard/CategoryCard.tsx
@@ -1,0 +1,26 @@
+import { Icon, type IconName } from "@/components/Elements/Icon"
+import { getCategories, type CategoryType } from "@/lib/categories"
+import { type Component } from "solid-js"
+import { twMerge } from "tailwind-merge"
+
+const categories = await getCategories()
+
+export type CategoryCardProps = {
+  id: CategoryType["id"]
+}
+
+export const CategoryCard: Component<CategoryCardProps> = (props) => {
+  const category = categories.find((category) => category.id === props.id)!
+  return (
+    <a
+      href={`/categories/${props.id}`}
+      class={twMerge(
+        "m-1 flex flex-row items-center gap-1 rounded-md bg-blue-400 px-2.5 py-1 text-sm font-bold text-white transition hover:brightness-110 sm:px-4 sm:text-base",
+        category.data.twClassName,
+      )}
+    >
+      <Icon name={category.data.icon as IconName} class="h-5 w-5" />
+      <div>{category.data.title}</div>
+    </a>
+  )
+}

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,9 @@
+import { getCollection } from "astro:content"
+
+const categoryCollection = await getCollection("categories")
+
+export type CategoryType = (typeof categoryCollection)[number]
+
+export const getCategories = async (): Promise<CategoryType[]> => {
+  return categoryCollection
+}

--- a/src/pages/categories/index.astro
+++ b/src/pages/categories/index.astro
@@ -1,0 +1,47 @@
+---
+import { CategoryCard } from "@/components/Elements/PostCard/CategoryCard"
+import { Tabs, type TabsProps } from "@/components/Elements/Tabs"
+import { BaseLayout } from "@/layouts/BaseLayout"
+import { getCategories } from "@/lib/categories"
+
+const categories = await getCategories()
+
+const tabProps: TabsProps = {
+  tabs: [
+    {
+      value: "アーカイブ",
+      icon: "tabler:archive",
+      href: "/archives",
+    },
+    {
+      value: "カテゴリ",
+      icon: "tabler:category",
+      href: "/categories",
+      isActive: true,
+    },
+    {
+      value: "タグ",
+      icon: "tabler:tag",
+      href: "/tags",
+    },
+  ],
+}
+---
+
+<BaseLayout
+  title="カテゴリ"
+  description="東京理科大学 電子計算機研究会 プログラミング班"
+  og={{
+    url: Astro.site!,
+  }}
+>
+  <main class="flex flex-1 flex-col gap-6 py-12">
+    <div>
+      <Tabs {...tabProps} />
+    </div>
+
+    <div class="flex flex-wrap">
+      {categories.map((category) => <CategoryCard id={category.id} />)}
+    </div>
+  </main>
+</BaseLayout>


### PR DESCRIPTION
close https://github.com/ricora/alg-blog/issues/124

## 備考

- 既存のカテゴリ表示には手を加えていない