### PR TITLE
fix: 記事の旧エンドポイントからのリダイレクトが誤っているバグを修正

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -28,7 +28,8 @@ import sitemap from "@astrojs/sitemap"
 export default defineConfig({
   site: "https://alg.tus-ricora.com/",
   redirects: {
-    "/p/[...slug]": "/posts/[...slug]",
+    // NOTE: Astroのバグで誤ったリダイレクト用のページが生成されるので、解決されるまでこの設定は無効化し、手動でリダイレクト用のページを生成する
+    //"/p/[...slug]": "/posts/[...slug]",
     "/link": "/links",
   },
   integrations: [tailwind(), solidJs(), mdx(), sitemap(), pagefind()],

--- a/src/pages/p/[...slug]/index.astro
+++ b/src/pages/p/[...slug]/index.astro
@@ -1,0 +1,33 @@
+---
+import { getPosts } from "@/lib/posts"
+import type { CollectionEntry } from "astro:content"
+import path from "path"
+
+export const getStaticPaths = async () => {
+  const postEntries = await getPosts()
+  return postEntries.map((post) => ({
+    params: {
+      slug: post.slug,
+    },
+    props: {
+      post,
+    },
+  }))
+}
+
+type Props = {
+  post: CollectionEntry<"posts">
+}
+const { post } = Astro.props
+
+const redirectToUrl = new URL(path.join("posts", post.slug), Astro.site!).href
+---
+
+<!doctype html>
+<title>Redirecting to: {redirectToUrl}</title><meta http-equiv="refresh" content=`0;url=${redirectToUrl}` /><meta
+  name="robots"
+  content="noindex"
+/><link rel="canonical" href={redirectToUrl} />
+<body>
+  <a href={redirectToUrl}>Redirecting from <code>/p/{post.slug}/</code> to <code>/posts/{post.slug}/</code></a>
+</body>


### PR DESCRIPTION
close https://github.com/ricora/alg-blog/issues/109

## 確認事項

- 正しいリダイレクトが行われるページが生成される

