### PR TITLE
feat: SP用のNavBarのベースを実装

### DIFF
--- a/src/components/SideBar/NavBar/Links.astro
+++ b/src/components/SideBar/NavBar/Links.astro
@@ -1,5 +1,6 @@
 ---
 import { Icon, type IconName } from "@/components/Elements/Icon"
+import { twMerge } from "tailwind-merge"
 
 type Link = {
   title: string
@@ -58,14 +59,22 @@ const links: Link[] = [
     href: "/link",
   },
 ]
+
+type Props = {
+  class?: string
+}
+const props = Astro.props
 ---
 
-<div class="hidden flex-col overflow-y-auto md:flex">
+<div class="flex flex-col overflow-y-auto md:w-full">
   {
     links.map((link) => (
       <a
         href={link.href}
-        class="flex flex-row gap-4 rounded-md p-2 text-fg-muted transition hover:bg-bg-muted hover:text-fg-default"
+        class={twMerge(
+          "flex flex-row gap-4 rounded-md p-2 text-fg-muted transition hover:bg-bg-muted hover:text-fg-default",
+          props.class,
+        )}
       >
         <Icon name={link.icon} class="h-6 w-6" />
         <span>{link.title}</span>

--- a/src/components/SideBar/NavBar/NavBar.astro
+++ b/src/components/SideBar/NavBar/NavBar.astro
@@ -61,9 +61,9 @@ const { class: className, ...props } = Astro.props
   </div>
   <NavDrawer client:load class="md:hidden">
     <Icon slot="closeButtonIcon" name="tabler:x" class="h-6 w-6" />
-    <Icon slot="githubIcon" name="tabler:brand-github" class="h-6 w-6 hover:text-fg-default" />
-    <Icon slot="twitterIcon" name="tabler:brand-twitter" class="h-6 w-6 hover:text-fg-default" />
-    <Icon slot="youtubeIcon" name="tabler:brand-youtube" class="h-6 w-6 hover:text-fg-default" />
+    <Icon slot="githubIcon" name="tabler:brand-github" class="h-6 w-6" />
+    <Icon slot="twitterIcon" name="tabler:brand-twitter" class="h-6 w-6" />
+    <Icon slot="youtubeIcon" name="tabler:brand-youtube" class="h-6 w-6" />
     <Links slot="links" />
   </NavDrawer>
 </aside>

--- a/src/components/SideBar/NavBar/NavBar.astro
+++ b/src/components/SideBar/NavBar/NavBar.astro
@@ -6,6 +6,7 @@ import Links from "./Links.astro"
 import { ToggleThemeButton } from "./ToggleThemeButton"
 import { Icon } from "@/components/Elements/Icon"
 import { SearchModal } from "./SearchModal"
+import { NavDrawer } from "./NavDrawer"
 
 type Props = HTMLAttributes<"aside">
 const { class: className, ...props } = Astro.props
@@ -19,24 +20,28 @@ const { class: className, ...props } = Astro.props
 
 <aside
   class={twMerge(
-    "flex flex-col gap-4 py-12 md:sticky md:top-0 md:h-dvh md:max-w-[25%] lg:max-w-[20%] xl:max-w-[15%]",
+    "flex flex-row md:flex-col gap-1 md:gap-4 py-3 md:py-12 px-4 md:px-0 sticky top-0 md:h-dvh md:max-w-[25%] lg:max-w-[20%] xl:max-w-[15%] items-center md:items-start backdrop-blur-xl border-b md:border-b-0 dark:backdrop-brightness-[0.3] backdrop-brightness-150 md:backdrop-filter-none md:dark:backdrop-filter-none",
     className,
   )}
   data-pagefind-ignore="all"
   {...props}
 >
-  <a href="/" class="mx-2 h-fit w-fit">
-    <Icon name="brand:ricora" alt="RICORA" class="h-32 w-32 rounded-full bg-bg-default p-2 shadow-md" />
+  <a href="/" class="h-fit w-fit md:mx-2">
+    <Icon
+      name="brand:ricora"
+      alt="RICORA"
+      class="h-6 w-6 rounded-full shadow-md md:h-32 md:w-32 md:bg-bg-default md:p-2"
+    />
   </a>
-  <div class="mx-2 flex flex-col gap-2">
-    <h1 class="text-xl font-bold">RICORA Programming Team</h1>
-    <h2 class="gap-2 text-sm text-fg-muted">
-      <span class="inline-block">東京理科大学<span> </span></span>
-      <span class="inline-block">電子計算機研究会<span> </span></span>
+  <div class="ml-1 mr-auto flex flex-col gap-2 md:mx-2">
+    <h1 class="text-sm font-bold md:text-xl">RICORA Programming Team</h1>
+    <h2 class="hidden gap-2 text-sm text-fg-muted md:block">
+      <span class="inline-block">東京理科大学&nbsp;</span>
+      <span class="inline-block">電子計算機研究会&nbsp;</span>
       <span class="inline-block">プログラミング班</span>
     </h2>
   </div>
-  <div class="mx-2 flex flex-row gap-2">
+  <div class="mx-2 hidden flex-row gap-2 md:flex">
     <IconLink name="line-md:github-loop" label="GitHub" href="https://github.com/RICORA/" client:load />
     <IconLink name="line-md:twitter-x" label="X (旧Twitter)" href="https://twitter.com/ricora_alg/" client:load />
     <IconLink
@@ -46,7 +51,7 @@ const { class: className, ...props } = Astro.props
       client:load
     />
   </div>
-  <Links />
+  <Links class="hidden md:flex" />
   <SearchModal client:only="solid">
     <Icon slot="searchIcon" name="tabler:search" class="h-6 w-6" />
     <Icon slot="buttonIcon" name="tabler:search" class="h-6 w-6" />
@@ -54,4 +59,11 @@ const { class: className, ...props } = Astro.props
   <div class="mt-auto hidden p-2 md:flex">
     <ToggleThemeButton client:only="solid" />
   </div>
+  <NavDrawer client:load class="md:hidden">
+    <Icon slot="closeButtonIcon" name="tabler:x" class="h-6 w-6" />
+    <Icon slot="githubIcon" name="tabler:brand-github" class="h-6 w-6 hover:text-fg-default" />
+    <Icon slot="twitterIcon" name="tabler:brand-twitter" class="h-6 w-6 hover:text-fg-default" />
+    <Icon slot="youtubeIcon" name="tabler:brand-youtube" class="h-6 w-6 hover:text-fg-default" />
+    <Links slot="links" />
+  </NavDrawer>
 </aside>

--- a/src/components/SideBar/NavBar/NavDrawer.tsx
+++ b/src/components/SideBar/NavBar/NavDrawer.tsx
@@ -45,7 +45,9 @@ export const NavDrawer: Component<NavDrawer> = (props) => {
             </Drawer.Header>
             <Drawer.Body>{props.links}</Drawer.Body>
             <Drawer.Footer>
-              <ToggleThemeButton class="mr-auto" />
+              <div class="mr-auto">
+                <ToggleThemeButton />
+              </div>
             </Drawer.Footer>
           </Drawer.Content>
         </Drawer.Positioner>

--- a/src/components/SideBar/NavBar/NavDrawer.tsx
+++ b/src/components/SideBar/NavBar/NavDrawer.tsx
@@ -44,8 +44,8 @@ export const NavDrawer: Component<NavDrawer> = (props) => {
               </Drawer.CloseTrigger>
             </Drawer.Header>
             <Drawer.Body>{props.links}</Drawer.Body>
-            <Drawer.Footer class="mr-auto">
-              <ToggleThemeButton />
+            <Drawer.Footer>
+              <ToggleThemeButton class="mr-auto" />
             </Drawer.Footer>
           </Drawer.Content>
         </Drawer.Positioner>

--- a/src/components/SideBar/NavBar/NavDrawer.tsx
+++ b/src/components/SideBar/NavBar/NavDrawer.tsx
@@ -34,9 +34,15 @@ export const NavDrawer: Component<NavDrawer> = (props) => {
                   <span class="inline-block">プログラミング班</span>
                 </Drawer.Description>
                 <div class="flex flex-row gap-2 text-fg-muted">
-                  {props.githubIcon}
-                  {props.twitterIcon}
-                  {props.youtubeIcon}
+                  <a class="hover:text-fg-default" href="https://github.com/RICORA/">
+                    {props.githubIcon}
+                  </a>
+                  <a class="hover:text-fg-default" href="https://twitter.com/ricora_alg/">
+                    {props.twitterIcon}
+                  </a>
+                  <a class="hover:text-fg-default" href="https://www.youtube.com/channel/UC4qBY_aaTvTkQ3E0PY89T2">
+                    {props.youtubeIcon}
+                  </a>
                 </div>
               </div>
               <Drawer.CloseTrigger class="mb-auto rounded-lg p-2 transition hover:bg-bg-muted">

--- a/src/components/SideBar/NavBar/NavDrawer.tsx
+++ b/src/components/SideBar/NavBar/NavDrawer.tsx
@@ -1,0 +1,55 @@
+import type { Component, JSX } from "solid-js"
+import * as Drawer from "@/components/ui/Drawer"
+import { Icon } from "@/components/Elements/Icon"
+import { Portal } from "solid-js/web"
+import { ToggleThemeButton } from "./ToggleThemeButton"
+
+export type NavDrawer = {
+  class?: string
+  closeButtonIcon?: JSX.Element
+  githubIcon?: JSX.Element
+  twitterIcon?: JSX.Element
+  youtubeIcon?: JSX.Element
+  links?: JSX.Element
+}
+
+export const NavDrawer: Component<NavDrawer> = (props) => {
+  return (
+    <Drawer.Root variant="left">
+      <Drawer.Trigger class={props.class}>
+        <div class="rounded-md p-2 text-fg-muted transition hover:bg-bg-muted hover:text-fg-default">
+          <Icon name="tabler:align-right" class="h-6 w-6" />
+        </div>
+      </Drawer.Trigger>
+      <Portal mount={document.querySelector("#modal")!}>
+        <Drawer.Backdrop />
+        <Drawer.Positioner>
+          <Drawer.Content class="mr-auto max-w-[80%]">
+            <Drawer.Header class="flex flex-row justify-between">
+              <div class="flex flex-col gap-2">
+                <Drawer.Title>RICORA Programming Team</Drawer.Title>
+                <Drawer.Description class="block gap-2">
+                  <span class="inline-block">東京理科大学&nbsp;</span>
+                  <span class="inline-block">電子計算機研究会&nbsp;</span>
+                  <span class="inline-block">プログラミング班</span>
+                </Drawer.Description>
+                <div class="flex flex-row gap-2 text-fg-muted">
+                  {props.githubIcon}
+                  {props.twitterIcon}
+                  {props.youtubeIcon}
+                </div>
+              </div>
+              <Drawer.CloseTrigger class="mb-auto rounded-lg p-2 transition hover:bg-bg-muted">
+                <div>{props.closeButtonIcon}</div>
+              </Drawer.CloseTrigger>
+            </Drawer.Header>
+            <Drawer.Body>{props.links}</Drawer.Body>
+            <Drawer.Footer class="mr-auto">
+              <ToggleThemeButton />
+            </Drawer.Footer>
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Portal>
+    </Drawer.Root>
+  )
+}

--- a/src/components/SideBar/NavBar/SearchModal.tsx
+++ b/src/components/SideBar/NavBar/SearchModal.tsx
@@ -16,9 +16,9 @@ export const SearchModal: Component<SearchModalProps> = (props) => {
 
   return (
     <Dialog.Root closeOnEscapeKeyDown closeOnInteractOutside open={isOpen()} onOpenChange={(e) => setIsOpen(e.open)}>
-      <Dialog.Trigger class="flex flex-row gap-4 rounded-md p-2 text-fg-muted transition hover:bg-bg-muted hover:text-fg-default">
+      <Dialog.Trigger class="flex flex-row gap-4 rounded-md p-2 text-fg-muted transition hover:bg-bg-muted hover:text-fg-default md:w-full">
         {props.buttonIcon}
-        <span>検索</span>
+        <span class="hidden md:inline-block">検索</span>
       </Dialog.Trigger>
       <Portal mount={document.querySelector("#modal")!}>
         <Dialog.Backdrop class="h-dvh w-dvw bg-black/50 opacity-100 transition-opacity data-[state=closed]:opacity-0" />

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,0 +1,77 @@
+import { ark, Dialog as ArkDrawer } from "@ark-ui/solid"
+import type { ComponentProps } from "solid-js"
+import { tv } from "tailwind-variants"
+import { createStyleContext } from "@/lib/create-style-context"
+
+const styles = tv(
+  {
+    base: "drawer",
+    defaultVariants: { variant: "right" },
+    slots: {
+      trigger: "drawer__trigger",
+      backdrop: "drawer__backdrop",
+      positioner: "drawer__positioner",
+      content: "drawer__content",
+      title: "drawer__title",
+      description: "drawer__description",
+      closeTrigger: "drawer__closeTrigger",
+      header: "drawer__header",
+      body: "drawer__body",
+      footer: "drawer__footer",
+    },
+    variants: {
+      variant: {
+        left: {
+          trigger: "drawer__trigger--variant_left",
+          backdrop: "drawer__backdrop--variant_left",
+          positioner: "drawer__positioner--variant_left",
+          content: "drawer__content--variant_left",
+          title: "drawer__title--variant_left",
+          description: "drawer__description--variant_left",
+          closeTrigger: "drawer__closeTrigger--variant_left",
+          header: "drawer__header--variant_left",
+          body: "drawer__body--variant_left",
+          footer: "drawer__footer--variant_left",
+        },
+        right: {
+          trigger: "drawer__trigger--variant_right",
+          backdrop: "drawer__backdrop--variant_right",
+          positioner: "drawer__positioner--variant_right",
+          content: "drawer__content--variant_right",
+          title: "drawer__title--variant_right",
+          description: "drawer__description--variant_right",
+          closeTrigger: "drawer__closeTrigger--variant_right",
+          header: "drawer__header--variant_right",
+          body: "drawer__body--variant_right",
+          footer: "drawer__footer--variant_right",
+        },
+      },
+    },
+  },
+  { twMerge: false },
+)
+const { withProvider, withContext } = createStyleContext(styles)
+
+export const Root = withProvider(ArkDrawer.Root)
+export const Backdrop = withContext(ArkDrawer.Backdrop, "backdrop")
+export const Body = withContext(ark.div, "body")
+export const CloseTrigger = withContext(ArkDrawer.CloseTrigger, "closeTrigger")
+export const Content = withContext(ArkDrawer.Content, "content")
+export const Description = withContext(ArkDrawer.Description, "description")
+export const Footer = withContext(ark.div, "footer")
+export const Header = withContext(ark.div, "header")
+export const Positioner = withContext(ArkDrawer.Positioner, "positioner")
+export const Title = withContext(ArkDrawer.Title, "title")
+export const Trigger = withContext(ArkDrawer.Trigger, "trigger")
+
+export type RootProps = ComponentProps<typeof Root>
+export interface BackdropProps extends ComponentProps<typeof Backdrop> {}
+export interface BodyProps extends ComponentProps<typeof Body> {}
+export interface CloseTriggerProps extends ComponentProps<typeof CloseTrigger> {}
+export interface ContentProps extends ComponentProps<typeof Content> {}
+export interface DescriptionProps extends ComponentProps<typeof Description> {}
+export interface FooterProps extends ComponentProps<typeof Footer> {}
+export interface HeaderProps extends ComponentProps<typeof Header> {}
+export interface PositionerProps extends ComponentProps<typeof Positioner> {}
+export interface TitleProps extends ComponentProps<typeof Title> {}
+export interface TriggerProps extends ComponentProps<typeof Trigger> {}

--- a/src/layouts/BaseLayout/BaseLayout.astro
+++ b/src/layouts/BaseLayout/BaseLayout.astro
@@ -89,9 +89,9 @@ const bundledThemeScript = "console.time('theme');" + result.outputFiles[0].text
   </head>
   <body class="bg-bg-canvas text-fg-default">
     <script is:inline set:html={bundledThemeScript} />
-    <div class="relative mx-auto flex h-fit min-h-full flex-col px-4 md:flex-row md:gap-8 xl:max-w-[1536px]">
+    <div class="relative mx-auto flex h-fit min-h-full flex-col md:flex-row md:gap-8 md:px-4 xl:max-w-[1536px]">
       <NavBar />
-      <div class="flex flex-1 flex-col gap-8">
+      <div class="flex flex-1 flex-col gap-8 px-4 md:px-0">
         <slot />
         <footer class="p-4 text-center">
           &copy; {new Date().getFullYear()} RICORA Programming Team

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,10 +60,8 @@ const contents: ContentType[] = [
           <div class="mx-auto max-w-screen-xl">
             <div class="flex flex-col gap-6 rounded-lg border bg-bg-default p-6 md:px-12 md:py-8">
               <h2 class="flex flex-row items-center gap-3 text-2xl font-black md:text-3xl">
-                <>
-                  <Icon name={content.headerIcon} class="w-10 flex-none md:w-12" />
-                  <span>{content.headerTitle}</span>
-                </>
+                <Icon name={content.headerIcon} class="w-10 flex-none md:w-12" />
+                <span>{content.headerTitle}</span>
               </h2>
               {content.description && <p class="text-fg-muted md:text-lg">{content.description}</p>}
 


### PR DESCRIPTION
close #143 

## 変更点

スマホ用のNavBarのベースを実装した

## 確認事項

デスクトップ画面とスマホ画面の両方でNavBarを正常に利用できること

## 備考

実装においては、コードの重複などがあり、リファクタリングの余地が大いにあるが、これらは #42 にてNavBarを再実装する際に対応する