### PR TITLE
docs(members): Kattyanの自己紹介文に"2024年度代表。"を追加

### DIFF
--- a/src/content/members/sou1118.yaml
+++ b/src/content/members/sou1118.yaml
@@ -1,5 +1,5 @@
 name: Kattyan
-description: 情報計算科学科。コンパイラや動画編集ソフトを作ってます。Arch Linux + Sway は良いです。
+description: 2024年度代表。情報計算科学科。コンパイラや動画編集ソフトを作ってます。Arch Linux + Sway は良いです。
 image: https://avatars.githubusercontent.com/u/48943030
 social:
   - icon: simple-icons:github


### PR DESCRIPTION
## 変更点

- Kattyanの自己紹介文の冒頭に"2024年度代表。"を追加した