### PR TITLE
feat: 記事の投稿日時と更新日時が等しいときに更新日時を表示しないように変更

### DIFF
--- a/src/components/Elements/PostCard/PostCard.tsx
+++ b/src/components/Elements/PostCard/PostCard.tsx
@@ -53,7 +53,7 @@ export const PostCard: Component<PostCardProps> = (props) => {
             <Icon name="tabler:calendar-time" class="h-4 w-4 sm:h-5 sm:w-5" />
             <span>投稿: {formatDate(props.date)}</span>
           </div>
-          {props.lastmod && (
+          {props.lastmod && props.lastmod.getTime() !== props.date.getTime() && (
             <div class="flex flex-row items-center gap-2">
               <Icon name="tabler:refresh" class="h-5 w-5" />
               <span>最終更新: {formatDate(props.lastmod)}</span>

--- a/src/layouts/PostLayout/PostLayout.astro
+++ b/src/layouts/PostLayout/PostLayout.astro
@@ -55,7 +55,7 @@ const ogImageUrl = new URL(path.join("posts", `${post.slug}.png`), Astro.site)
             </div>
           </div>
           {
-            lastmod && (
+            lastmod && post.data.date.getTime() !== post.data.lastmod?.getTime() && (
               <div class="mx-auto my-2">
                 <div class="font-bold">最終更新</div>
                 <div>{lastmod}</div>


### PR DESCRIPTION
fix #167

## 確認事項

- PostCardで記事の投稿日時と更新日時が等しいときは更新日時を表示されないこと
- 各記事のページで記事の投稿日時と更新日時が等しいときは更新日時を表示しない