### PR TITLE
fix: `/about-us`を`/about`に変更

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     // NOTE: Astroのバグで誤ったリダイレクト用のページが生成されるので、解決されるまでこの設定は無効化し、手動でリダイレクト用のページを生成する
     //"/p/[...slug]": "/posts/[...slug]",
     "/link": "/links",
+    "/about-us": "/about",
   },
   integrations: [tailwind(), solidJs(), mdx(), sitemap(), pagefind()],
   markdown: {

--- a/src/components/SideBar/NavBar/Links.astro
+++ b/src/components/SideBar/NavBar/Links.astro
@@ -41,7 +41,7 @@ const links: Link[] = [
   {
     title: "RICORAについて",
     icon: "tabler:info-circle",
-    href: "/about-us",
+    href: "/about",
   },
   {
     title: "お問い合わせ",
@@ -56,7 +56,7 @@ const links: Link[] = [
   {
     title: "リンク",
     icon: "tabler:link",
-    href: "/link",
+    href: "/links",
   },
 ]
 

--- a/src/content/pages/about/index.mdx
+++ b/src/content/pages/about/index.mdx
@@ -3,7 +3,6 @@ title: RICORAについて
 draft: false
 date: 2022-02-15
 lastmod: 2022-02-15
-slug: about-us
 ---
 
 ## サークルについて

--- a/src/content/posts/welcome-event-2022-schedule.mdx
+++ b/src/content/posts/welcome-event-2022-schedule.mdx
@@ -15,7 +15,7 @@ import { Schedule } from "@/components/Elements/Schedule"
 
 RICORAプログラミング班に興味を持って頂きありがとうございます！この記事では2022年度の春の新歓の日程をご紹介します。たくさんのイベントをご用意しましたので、ぜひお越しください！
 
-RICORAプログラミング班についての詳しい説明は[RICORAについて](/about-us/)をご覧ください。
+RICORAプログラミング班についての詳しい説明は[RICORAについて](/about)をご覧ください。
 
 ## 春の新歓の日程
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ const contents: ContentType[] = [
     description:
       "RICORA Programming Teamは東京理科大学 野田キャンパスにて活動するプログラミングサークルです。低レイヤー領域の探究から競技プログラミング、CTF、ゲーム制作、Web開発など多岐にわたり活動を行っています。",
     linkTitle: "もっと詳しく見る",
-    link: "/about-us",
+    link: "/about",
   },
   {
     headerTitle: "最新ニュース",


### PR DESCRIPTION
## 変更点

- `/about-us`から`/about`へエンドポイントを変更した
- `/about-us`から`/about`へのリダイレクトを追加
- NavBarのリンクを新たなものへ更新