### PR TITLE
fix: コードブロックで空白行が表示されないバグを修正

### DIFF
--- a/src/components/Elements/CodeBlock/shiki.css
+++ b/src/components/Elements/CodeBlock/shiki.css
@@ -14,7 +14,7 @@
   }
 
   & span.line {
-    @apply border-l-2 border-l-transparent px-4;
+    @apply h-6 border-l-2 border-l-transparent px-4;
   }
 
   /* 行番号表示 */


### PR DESCRIPTION
fix #173 

## 変更点

- コードブロックの1行の高さを固定することで、空白行も表示されるよう修正

## 確認事項

- `/mdx-guide`にある空白行を含むコードブロックで、空白行が表示されていること。また、全てのコードブロックで各行の高さが適切であること。