### PR TITLE
chore: CI/CDで依存関係のインストール前にNode.jsをセットアップするように修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-      - name: Install dependencies
-        run: bun install
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install
       - name: Build
         run: bun run astro check && bun run astro build
       - name: Upload Pages Artifact


### PR DESCRIPTION
## モチベーション

- Sharpなどではパッケージのインストール時にNode.jsが実行されるので、`bun install`前にNode.jsをセットアップしておきたい

## 変更点

- CDで依存関係のインストール前にNode.jsをセットアップするよう修正