### PR TITLE
feat: Park UIのCodeを追加

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -23,6 +23,7 @@ import remarkMath from "remark-math"
 import rehypeKatex from "rehype-katex"
 import { pagefind } from "./src/lib/astro-integrations/pagefind"
 import sitemap from "@astrojs/sitemap"
+import { remarkInlineCode } from "@/lib/remark-plugins/remarkInlineCode"
 
 // https://astro.build/config
 export default defineConfig({
@@ -37,6 +38,7 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [
       remarkMath,
+      remarkInlineCode,
       remarkCallout,
       remarkMetaString,
       [

--- a/src/components/ui/Code.tsx
+++ b/src/components/ui/Code.tsx
@@ -1,0 +1,24 @@
+import { ark, type HTMLArkProps } from "@ark-ui/solid"
+import { splitProps } from "solid-js"
+import { tv, type VariantProps } from "tailwind-variants"
+
+export interface CodeProps extends CodeVariantProps, HTMLArkProps<"code"> {}
+
+export const Code = (props: CodeProps) => {
+  const [variantProps, codeProps] = splitProps(props, ["class", "size"])
+  return <ark.code class={styles(variantProps)} {...codeProps} />
+}
+
+type CodeVariantProps = VariantProps<typeof styles>
+
+const styles = tv(
+  {
+    base: "code not-prose",
+    defaultVariants: { size: "md", variant: "outline" },
+    variants: {
+      variant: { outline: "code--variant_outline", ghost: "code--variant_ghost" },
+      size: { sm: "code--size_sm", md: "code--size_md", lg: "code--size_lg" },
+    },
+  },
+  { twMerge: false },
+)

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -2,6 +2,7 @@ import { Callout, CalloutTitle } from "@/components/Elements/Callout"
 import { CodeBlock } from "@/components/Elements/CodeBlock"
 import { OEmbed } from "@/components/Elements/Embed"
 import { LinkCard } from "@/components/Elements/LinkCard"
+import { Code } from "@/components/ui/Code"
 
 export const mdxComponents = {
   callout: Callout,
@@ -9,4 +10,5 @@ export const mdxComponents = {
   pre: CodeBlock,
   "link-card": LinkCard,
   oembed: OEmbed,
+  code: Code,
 }

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -10,5 +10,5 @@ export const mdxComponents = {
   pre: CodeBlock,
   "link-card": LinkCard,
   oembed: OEmbed,
-  code: Code,
+  "inline-code": Code,
 }

--- a/src/lib/remark-plugins/remarkInlineCode.test.ts
+++ b/src/lib/remark-plugins/remarkInlineCode.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import dedent from "dedent"
+import type * as hast from "hast"
+import { JSDOM } from "jsdom"
+import type * as mdast from "mdast"
+import rehypeStringify from "rehype-stringify"
+import remarkParse from "remark-parse"
+import remarkRehype from "remark-rehype"
+import { unified } from "unified"
+import { remarkInlineCode } from "./remarkInlineCode"
+
+const process = async (md: string) => {
+  let hast: hast.Node
+  let mdast: mdast.Root
+  const html = (
+    await unified()
+      .use(remarkParse)
+      .use(remarkInlineCode)
+      .use(() => (tree: mdast.Root) => {
+        mdast = tree
+        return mdast
+      })
+      .use(remarkRehype)
+      .use(() => (tree: hast.Node) => {
+        hast = tree
+        return hast
+      })
+      .use(rehypeStringify)
+      .process(md)
+  ).toString()
+
+  // @ts-expect-error: hast and mdast is assigned
+  return { hast, mdast, html }
+}
+
+describe("remarkInlineCode", () => {
+  let jsdom: JSDOM
+  let parser: DOMParser
+
+  beforeAll(() => {
+    jsdom = new JSDOM()
+    parser = new jsdom.window.DOMParser()
+  })
+
+  test("a inline code should be wrapped with `inline-code` element", async () => {
+    const md = dedent`
+      This is a paragraph with \`inline code\` in it.
+    `
+
+    const { html } = await process(md)
+    const doc = parser.parseFromString(html, "text/html")
+
+    const inlineCodeElement = doc.querySelector("inline-code")
+    expect(inlineCodeElement).not.toBeNull()
+
+    expect(inlineCodeElement?.textContent).toBe("inline code")
+  })
+})

--- a/src/lib/remark-plugins/remarkInlineCode.ts
+++ b/src/lib/remark-plugins/remarkInlineCode.ts
@@ -1,0 +1,12 @@
+import type { Root } from "mdast"
+import { type Plugin } from "unified"
+import { visit } from "unist-util-visit"
+
+export const remarkInlineCode: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, "inlineCode", (node) => {
+      if (!node.data) node.data = {}
+      node.data.hName = "inline-code"
+    })
+  }
+}


### PR DESCRIPTION
close https://github.com/ricora/alg.tus-ricora.com/issues/190

## 変更点

- [Park UIのCodeコンポーネント](https://park-ui.com/docs/tailwind/components/code)を追加
- MDX内の`code`要素をコンポーネントに置換する設定を追加

## 確認事項

- サイト内で追加したコンポーネントが利用できる
- MDX内の`code`要素が正常に置換される