### PR TITLE
feat: 記事ページにカテゴリとタグの表示を実装

### DIFF
--- a/src/components/Elements/PostCard/TagCard.tsx
+++ b/src/components/Elements/PostCard/TagCard.tsx
@@ -1,0 +1,21 @@
+import { getTags } from "@/lib/tags"
+import { type Component } from "solid-js"
+
+const tags = await getTags()
+
+export type TagCardProps = {
+  id: string
+}
+
+export const TagCard: Component<TagCardProps> = (props) => {
+  const tag = tags.find((tag) => tag.id === props.id)!
+  return (
+    <a
+      href={`/tags/${tag.id}`}
+      class="m-1 rounded-lg border bg-bg-default px-4 py-2 text-sm transition hover:bg-bg-muted"
+    >
+      <span class="pr-1 text-xs text-fg-muted">#</span>
+      <span>{tag.title}</span>
+    </a>
+  )
+}

--- a/src/layouts/PostLayout/PostLayout.astro
+++ b/src/layouts/PostLayout/PostLayout.astro
@@ -1,6 +1,8 @@
 ---
 import "@/styles/katex.css"
 import { Icon, type IconName } from "@/components/Elements/Icon"
+import { CategoryCard } from "@/components/Elements/PostCard/CategoryCard"
+import { TagCard } from "@/components/Elements/PostCard/TagCard"
 import { BaseLayout, type BaseLayoutProps } from "@/layouts/BaseLayout"
 import { formatDate } from "@/lib/date"
 import { calculateReadingTime } from "@/lib/posts"
@@ -18,6 +20,8 @@ const { Content } = await post.render()
 const date = formatDate(post.data.date)
 const lastmod = post.data.lastmod ? formatDate(post.data.lastmod) : undefined
 const readingTime = calculateReadingTime(post.body)
+const categories = post.data.categories
+const tags = post.data.tags || []
 
 const postUrl = new URL(path.join("posts", post.slug), Astro.site)
 const ogImageUrl = new URL(path.join("posts", `${post.slug}.png`), Astro.site)
@@ -47,6 +51,10 @@ const ogImageUrl = new URL(path.join("posts", `${post.slug}.png`), Astro.site)
           pagefindImage
         />
         <h1 class="text-3xl font-bold" data-pagefind-meta="title">{post.data.title}</h1>
+        <div class="flex flex-wrap">
+          {categories.map((category) => <CategoryCard id={category.id} />)}
+          {tags.map((tag) => <TagCard id={tag} />)}
+        </div>
         <div class="flex w-full max-w-lg flex-row flex-wrap justify-between text-center">
           <div class="mx-auto my-2">
             <div class="font-bold">投稿</div>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,4 +1,5 @@
 ---
+import { TagCard } from "@/components/Elements/PostCard/TagCard"
 import { Tabs, type TabsProps } from "@/components/Elements/Tabs"
 import { BaseLayout } from "@/layouts/BaseLayout"
 import { getTags } from "@/lib/tags"
@@ -40,17 +41,7 @@ const tabProps: TabsProps = {
     </div>
 
     <div class="flex flex-wrap">
-      {
-        tags.map((tag) => (
-          <a
-            href={`/tags/${tag.id}`}
-            class="m-1 rounded-lg border bg-bg-default px-4 py-2 text-sm transition hover:bg-bg-muted"
-          >
-            <span class="pr-1 text-xs text-fg-muted">#</span>
-            <span>{tag.title}</span>
-          </a>
-        ))
-      }
+      {tags.map((tag) => <TagCard id={tag.id} />)}
     </div>
   </main>
 </BaseLayout>


### PR DESCRIPTION
close https://github.com/ricora/alg.tus-ricora.com/issues/121 close https://github.com/ricora/alg.tus-ricora.com/issues/122

## 変更点

- タグ一覧ページで使われていたタグカードをコンポーネントに分離した
- 記事ページにカテゴリとタグの表示を実装した

## 確認事項

- タグ一覧ページの表示が変化していない
- 記事ページでカテゴリとタグが正常に表示される