### PR TITLE
fix: カテゴリのアイコンの設定を統一

### DIFF
--- a/src/components/SideBar/NavBar/Links.astro
+++ b/src/components/SideBar/NavBar/Links.astro
@@ -15,17 +15,17 @@ const links: Link[] = [
   },
   {
     title: "お知らせ",
-    icon: "tabler:news",
+    icon: "tabler:speakerphone",
     href: "/categories/news",
   },
   {
     title: "活動記録",
-    icon: "tabler:activity",
+    icon: "tabler:book-2",
     href: "/categories/activities",
   },
   {
     title: "作品紹介",
-    icon: "tabler:star",
+    icon: "tabler:sparkles",
     href: "/categories/works",
   },
   {


### PR DESCRIPTION
close https://github.com/ricora/alg.tus-ricora.com/issues/229

## 変更点

- アイコンの設定を`src/content/categories/`で設定されているものに合わせて統一した

## 確認事項

- アイコンに設定された値が間違っていない