### PR TITLE
docs(posts): 過去記事の絵文字を季節にちなんだものに変更

### DIFF
--- a/src/content/posts/lt-20220329/index.mdx
+++ b/src/content/posts/lt-20220329/index.mdx
@@ -6,7 +6,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:japanese-dolls
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20220511/index.mdx
+++ b/src/content/posts/lt-20220511/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:carp-streamer
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20220622/index.mdx
+++ b/src/content/posts/lt-20220622/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:umbrella-with-rain-drops
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20220713/index.mdx
+++ b/src/content/posts/lt-20220713/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:tanabata-tree
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20220914/index.mdx
+++ b/src/content/posts/lt-20220914/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:moon-viewing-ceremony
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20221109/index.mdx
+++ b/src/content/posts/lt-20221109/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:fallen-leaf
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20221116/index.mdx
+++ b/src/content/posts/lt-20221116/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:roasted-sweet-potato
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20221221/index.mdx
+++ b/src/content/posts/lt-20221221/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:wrapped-gift
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20230602/index.mdx
+++ b/src/content/posts/lt-20230602/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:umbrella-with-rain-drops
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20231130/index.mdx
+++ b/src/content/posts/lt-20231130/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:fallen-leaf
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20231207/index.mdx
+++ b/src/content/posts/lt-20231207/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:wrapped-gift
 ---
 
 ## はじめに

--- a/src/content/posts/lt-20231214/index.mdx
+++ b/src/content/posts/lt-20231214/index.mdx
@@ -5,7 +5,7 @@ categories:
   - activities
 tags:
   - lightning-talk
-icon: fluent-emoji:pencil
+icon: fluent-emoji:birthday-cake
 ---
 
 ## はじめに


### PR DESCRIPTION
## 変更理由

- 記事一覧ページで同じ絵文字が連続すると見栄えが悪いため

## 確認事項

- 選定した絵文字が妥当かどうか