### PR TITLE
fix: aspect-ratioが指定されているiframeのwidthとheightを100%に変更

### DIFF
--- a/src/components/Elements/Embed/OEmbedRich.tsx
+++ b/src/components/Elements/Embed/OEmbedRich.tsx
@@ -1,7 +1,23 @@
+import { fromHtml } from "hast-util-from-html"
+import { select } from "hast-util-select"
+import { toHtml } from "hast-util-to-html"
 import type { Component } from "solid-js"
 import type { OEmbedRich as OEmbedRichSchema } from "./oEmbedSchema"
 import { sanitize } from "./sanitize"
 
+/**
+ * aspect-ratioが指定されているiframeのwidthとheightを100%に変更する
+ */
+const transform = (html: string) => {
+  const hast = fromHtml(html)
+  const iframe = select("iframe", hast)
+  if (iframe?.properties.style?.toString().includes("aspect-ratio:")) {
+    iframe.properties.width = "100%"
+    iframe.properties.height = "100%"
+  }
+  return toHtml(hast)
+}
+
 export const OEmbedRich: Component<{ oEmbed: OEmbedRichSchema }> = (props) => {
-  return <div class="w-full" innerHTML={sanitize(props.oEmbed.html)} data-oembed />
+  return <div class="w-full" innerHTML={transform(sanitize(props.oEmbed.html))} data-oembed />
 }

--- a/src/components/Elements/Embed/sanitize.ts
+++ b/src/components/Elements/Embed/sanitize.ts
@@ -4,4 +4,5 @@ export const sanitize = (html: string) =>
   DOMPurify.sanitize(html, {
     ADD_TAGS: ["iframe"],
     ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling"],
+    FORBID_ATTR: ["height", "width"],
   })

--- a/src/components/Elements/Embed/sanitize.ts
+++ b/src/components/Elements/Embed/sanitize.ts
@@ -4,5 +4,4 @@ export const sanitize = (html: string) =>
   DOMPurify.sanitize(html, {
     ADD_TAGS: ["iframe"],
     ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling"],
-    FORBID_ATTR: ["height", "width"],
   })


### PR DESCRIPTION
fix #300 

## 背景

html側で固定値のheight属性が付いているせいで、CSS側のaspect-ratioで計算された`height`値が無視されてhtml側の固定値が優先されている。これにより、CSSの`aspect-ratio`が維持されず、Docswellの埋め込みのサイズが崩れている。

## 対策

~~埋め込み用iframeのサニタイズ時に、heightとwidth属性を消すようにした。CSS側で`width: 100%`を常に指定しているため、`height`値はこの`width`とCSSの`aspect-ratio`で計算されたものとなる。`aspect-ratio`がない場合は、iframeの子要素の高さとなる。~~

`aspect-ratio`が指定されている埋め込み用のiframeに対してのみ、`width`と`height`属性をそれぞれ`100%`にする処理を追加した。