### PR TITLE
feat: `/posts`から`/archives`へのリダイレクトの設定を追加

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     //"/p/[...slug]": "/posts/[...slug]",
     "/link": "/links",
     "/about-us": "/about",
+    "/posts": "/archives",
   },
   integrations: [tailwind(), solidJs(), mdx(), sitemap(), pagefind()],
   markdown: {


### PR DESCRIPTION
close #165 

## 変更点

- `/posts`から`/archives`へのリダイレクトの設定を追加

## 確認事項

- `/posts`から`/archives`へのリダイレクトができる
