### PR TITLE
chore: VS Codeのtextlint拡張機能の校正対象にMDXを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     // e.g. twColor: text-red-6;
     // > https://github.com/tailwindlabs/tailwindcss-intellisense/issues/270
     "tw.*:(?:.|\n)*?[\"'`]([^\"'`]*).*?,"
-  ]
+  ],
+  "textlint.languages": ["markdown", "mdx"]
 }


### PR DESCRIPTION
<!--
close #xxx
-->

## 変更点

- VS Codeのtextlint拡張機能の校正対象にMDXを追加した

## 確認事項

- VS Code上でMDXファイルにルール違反の記述があるときにtextlintの指摘が表示される
